### PR TITLE
Use ENV_VAR instead of paths in properties of the build

### DIFF
--- a/pipelines/build.ps1
+++ b/pipelines/build.ps1
@@ -9,9 +9,9 @@
   $publishNugets = $false
   $updateAssemblyInfo = $false
   $gitVersion
-  $msbuild = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe"
-  $dotnet = "C:\Program Files\dotnet\dotnet.exe"
-  $devenv = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\devenv.com"
+  $msbuild = ([System.Environment]::GetEnvironmentVariable('TcoMsbuild'))
+  $dotnet = ([System.Environment]::GetEnvironmentVariable('TcoDotnet'))
+  $devenv = ([System.Environment]::GetEnvironmentVariable('TcoDevenv'))
   $testTargetAmsId = ([System.Environment]::GetEnvironmentVariable('Tc3Target'))
   $testingStrength = 0
 }


### PR DESCRIPTION
It's better to use EnvVariables for these paths
Someone has community, enterprise or proffesional... 
Oftentimes msbuild or dotnet are not enviroment variables, or ppl have more than one version and it's better to specify explicitely which one should the build process use.

$msbuild  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe"
$dotnet  "C:\Program Files\dotnet\dotnet.exe"
$devenv  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\devenv.com"