### PR TITLE
Build script, which just builds the solution

### DIFF
--- a/pipelines/build.ps1
+++ b/pipelines/build.ps1
@@ -18,7 +18,7 @@
 
 
 
-task default -depends CloseVs, Tests, CreatePackages, Finish
+task default -depends Init, CopyInxton, CloseVs, Build, Tests, CreatePackages, Finish
 
 
 FormatTaskName (("="*25) + " [ {0} ] " + ("="*25))
@@ -72,7 +72,10 @@ task CopyInxton -depends NugetRestore -continueOnError {
   }
 }
 
-task GitVersion -depends CopyInxton {
+task GitVersion `
+  -precondition { $updateAssemblyInfo } `
+  -depends CopyInxton `
+{
   EnsureGitVersion -pathToGitVersion ".\_toolz\gitversion.exe"
   $updateAssemblyInfoFlag = if( $updateAssemblyInfo)  {"/updateassemblyinfo"} else {""}
   $gitVersionOutput = & ".\_toolz\gitversion.exe" "$updateAssemblyInfoFlag" "/config" "$baseDir/GitVersion.yml"
@@ -235,13 +238,19 @@ task Tests -depends CloseVs  -precondition { return $isTestingEnabled } {
 } 
 
 
-task ClearPackages -depends Tests {
+task ClearPackages `
+  -precondition { $publishNugets } `
+  -depends Tests `
+{
   mkdir nugets -ErrorAction SilentlyContinue
   mkdir nugets\dependants -ErrorAction SilentlyContinue
   Get-ChildItem -Path .\nugets\ -Include *.* -File -Recurse | ForEach-Object { $_.Delete()}
 }
 
-task CreatePackages -depends ClearPackages {
+task CreatePackages `
+  -precondition { $publishNugets } `
+  -depends ClearPackages `
+{
   $semVer = $script:gitVersion.SemVer
   $projects = @(
     #Packaging


### PR DESCRIPTION
Execute gitversion only when updateAssembly info is true
Create packages only when publishNugets is true

Basically - build script should build the solution by default, it used to make a lot of unnecessary stuff. 

#87 #85