### PR TITLE
Test fixies messaging, cylinder

### DIFF
--- a/src/TcoCore/tests/TcoCoreUnitTests/TcoMessengerTests.cs
+++ b/src/TcoCore/tests/TcoCoreUnitTests/TcoMessengerTests.cs
@@ -21,7 +21,7 @@ namespace TcoCoreUnitTests
         public void OneSetup()
         {
             suc._callMyPlcInstanceRtcUpdate.Synchron = true;
-            sut.SingleCycleRun(() => { sut._minLevel.Synchron = (short)eMessageCategory.None; sut.SetMinLevel(); });
+            sut.SingleCycleRun(() => { sut._minLevel.Synchron = (short)eMessageCategory.All; sut.SetMinLevel(); });
             sut.SingleCycleRun(() => sut.Resume());
         }
 

--- a/src/TcoPneumatics/src/XaeTcoPneumatics/TcoPneumatics/POUs/Cylinders/Cylinder.TcPOU
+++ b/src/TcoPneumatics/src/XaeTcoPneumatics/TcoPneumatics/POUs/Cylinders/Cylinder.TcPOU
@@ -32,6 +32,8 @@ _moveWorkDefault(PositionSensor := inAtWorkPos,
     PositionName := '<#Work#>');
 
 IF (_stopDefault.Execute()) THEN
+	outToHomePos := FALSE;
+	outToWorkPos := FALSE;
     _moveHomeDefault.Abort();
     _moveWorkDefault.Abort();
     _stopDefault.Abort();

--- a/src/TcoPneumatics/tests/TcoPneumaticsTests_nUnit/CylinderTests.cs
+++ b/src/TcoPneumatics/tests/TcoPneumaticsTests_nUnit/CylinderTests.cs
@@ -16,7 +16,7 @@ namespace TcoPneumaticsTests
         [OneTimeSetUp()]
         public void OneTimeSetUp()
         {
-                 
+
         }
 
         [SetUp]
@@ -29,6 +29,7 @@ namespace TcoPneumaticsTests
 
         [Test]
         [Timeout(10000)]
+        [Order(100)]
         public void StopMovement()
         {
             sut._atHomeSignal.Synchron = false;
@@ -40,6 +41,7 @@ namespace TcoPneumaticsTests
 
         [Test]
         [Timeout(10000)]
+        [Order(200)]
         public void MoveHomeMoving()
         {            
             sut.ExecuteProbeRun(1, (int)eCyclinderTests.MoveHomeMoving);
@@ -55,6 +57,7 @@ namespace TcoPneumaticsTests
 
         [Test]
         [Timeout(10000)]
+        [Order(300)]
         public void MoveHomeMovingReached()
         {
             sut.ExecuteProbeRun(1, (int)eCyclinderTests.MoveHomeMovingReached);
@@ -77,6 +80,7 @@ namespace TcoPneumaticsTests
 
         [Test]
         [Timeout(10000)]
+        [Order(400)]
         public void MoveWorkMoving()
         {
             sut.ExecuteProbeRun(1, (int)eCyclinderTests.MoveWorkMoving);
@@ -92,6 +96,7 @@ namespace TcoPneumaticsTests
 
         [Test]
         [Timeout(10000)]
+        [Order(500)]
         public void MoveWorkMovingReached()
         {
             sut.ExecuteProbeRun(1, (int)eCyclinderTests.MoveWorkMovingReached);
@@ -114,6 +119,7 @@ namespace TcoPneumaticsTests
 
         [Test]
         [Timeout(10000)]
+        [Order(600)]
         public void AbortMoveTask()
         {
             sut.ExecuteProbeRun(1, (int)eCyclinderTests.MoveHomeMoving);
@@ -134,6 +140,7 @@ namespace TcoPneumaticsTests
 
         [Test]
         [Timeout(10000)]
+        [Order(700)]
         public void MoveTaskAlarm()
         {
             var timeToAlarm = new System.TimeSpan(0, 0, 0, 0, 50);


### PR DESCRIPTION
Some failing tests from the previous merge fixed:
- Messaging test failed due to MinSeverity initialization to `None` (now to `All`)
- Cylinder tests failed due to conflicting calls on disabled tasks now ordered in the sequence that does not produce conflict.