### PR TITLE
Run build action only PR and push to dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: Build
 
 on: 
   push:
+    branches : 
+      - dev
   pull_request: 
     paths:
       - 'src/**'


### PR DESCRIPTION
When we have a PR actions should run once.
It should run if there's a change in the PR
And when it's merged to dev

Hope it'll work.

Resources :
https://frontside.com/blog/2020-05-26-github-actions-pull_request/