### PR TITLE
Create branch and PR on issue

### DIFF
--- a/.github/issue-branch.yml
+++ b/.github/issue-branch.yml
@@ -1,0 +1,3 @@
+mode: chatops
+branchName: '${issue.number}-${issue.title}'
+openDraftPR: true

--- a/.github/workflows/create_issue.yml
+++ b/.github/workflows/create_issue.yml
@@ -1,0 +1,16 @@
+on:
+    issues:
+        types: [assigned]
+    issue_comment:
+        types: [created]
+    pull_request:
+        types: [closed]
+
+jobs:
+    create_issue_branch_job:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Create Issue Branch
+          uses: robvanderleek/create-issue-branch@master
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I'm a bit tired of creating branches and having to push new branch upstream...also creating pr, connecting it etc...

This way when I comment an issue with `/cib` or `/create-issue-branch`  new branch will be created and new draft PR will be created as well.