### PR TITLE
Use PAT to push to documentation repo.

### DIFF
--- a/.github/workflows/docu.yml
+++ b/.github/workflows/docu.yml
@@ -27,9 +27,11 @@ jobs:
             cd ..\..
       ###
       - name : Build TcOpen.Documentation
+        env:
+          TC_OPEN_GROUP_USER_PAT: ${{ secrets.TC_OPEN_GROUP_USER_PAT   }}
         run: |
             cd docu/TcOpen.Documentation
             dotnet build
             git add -A
             git commit -m "Automated update of documentation"
-            git push
+            git push "https://token:$env:TC_OPEN_GROUP_USER_PAT@github.com/TcOpenGroup/TcOpen.Documentation.git"


### PR DESCRIPTION
There were issues with pushing to the docu repository, cause when you clone the repository with github action, it overrides the authorization header.  

Hope this will resolve the issue.