### PR TITLE
Documentation use token push

### DIFF
--- a/.github/workflows/docu.yml
+++ b/.github/workflows/docu.yml
@@ -27,9 +27,11 @@ jobs:
             cd ..\..
       ###
       - name : Build TcOpen.Documentation
+        env:
+          TC_OPEN_GROUP_USER_PAT: ${{ secrets.TC_OPEN_GROUP_USER_PAT   }}
         run: |
             cd docu/TcOpen.Documentation
             dotnet build
             git add -A
             git commit -m "Automated update of documentation"
-            git push
+            git push "https://token:$env:TC_OPEN_GROUP_USER_PAT@github.com/TcOpenGroup/TcOpen.Documentation.git"

--- a/.github/workflows/docu.yml
+++ b/.github/workflows/docu.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           repository: TcOpenGroup/TcOpen.Documentation
           path: docu/TcOpen.Documentation
+          token: ${{ secrets.TC_OPEN_GROUP_USER_PAT }}
       ###
       - name : Build TcOpen
         run: |


### PR DESCRIPTION
Since it doesn't care about the token in push, I'm trying to clone the docu with the token