### PR TITLE
Float serialization from MongoDB

### DIFF
--- a/src/TcoData/TcoData.slnf
+++ b/src/TcoData/TcoData.slnf
@@ -5,6 +5,7 @@
       "src\\TcOpen.Inxton\\src\\Abstractions\\TcOpen.Inxton.Abstractions.csproj",
       "src\\TcOpen.Inxton\\src\\Application\\TcOpen.Inxton.App.csproj",
       "src\\TcOpen.Inxton\\src\\Logging\\TcoOpen.Inxton.Logging\\TcOpen.Inxton.Logging.csproj",
+      "src\\TcOpen.Inxton\\src\\TcOpen.Inxton\\TcOpen.Inxton.csproj",
       "src\\TcoCore\\src\\TcoCoreConnector\\TcoCoreConnector.csproj",
       "src\\TcoCore\\src\\XaeTcoCore\\XaeTcoCore.tsproj",
       "src\\TcoData\\src\\Data\\TcOpen.Inxton.Data.csproj",

--- a/src/TcoData/src/Repository/MongoDb/Mongo/FloatTruncationSerializer.cs
+++ b/src/TcoData/src/Repository/MongoDb/Mongo/FloatTruncationSerializer.cs
@@ -1,0 +1,32 @@
+﻿using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using System;
+
+namespace TcOpen.Inxton.Data.MongoDb
+{
+    /// <summary>
+    /// Write the float value to mongo as bool as read it back as float.
+    /// Useful if you want to rewrite the values in the DB and read it back in C# app.
+    /// </summary>
+    public class FloatTruncationSerializer : SerializerBase<float>
+    {
+        /// <inheritdoc/>
+        public override float Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            var value = context.Reader.ReadDouble();
+            if (value == double.Epsilon)
+                return float.Epsilon;
+            else
+                return (float)value;
+        }
+
+        /// <inheritdoc/>
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, float value)
+        {
+            if(value == float.Epsilon)
+                context.Writer.WriteDouble(double.Epsilon);
+            else
+                context.Writer.WriteDouble(Math.Round(value,10));
+        }
+    }
+}

--- a/src/TcoData/src/Repository/MongoDb/Mongo/MongoDbRepository.cs
+++ b/src/TcoData/src/Repository/MongoDb/Mongo/MongoDbRepository.cs
@@ -86,13 +86,11 @@ namespace TcOpen.Inxton.Data.MongoDb
             if (identifier == "*")
             {
                 return collection.Find(p => true)
-                    .Sort(new SortDefinitionBuilder<T>().Descending("$natural"))
                     .Limit(limit).Skip(skip).ToList();
             }
             else
             {
                 return collection.Find(p => p._EntityId.Contains(identifier))
-                    .Sort(new SortDefinitionBuilder<T>().Descending("$natural"))
                     .Limit(limit).Skip(skip).ToList();
             }
         }

--- a/src/TcoData/src/Repository/MongoDb/Mongo/MongoDbRepositorySettings.cs
+++ b/src/TcoData/src/Repository/MongoDb/Mongo/MongoDbRepositorySettings.cs
@@ -153,6 +153,7 @@ namespace TcOpen.Inxton.Data.MongoDb
                 BsonSerializer.RegisterSerializer(typeof(UInt64), new UInt64Serializer(BsonType.Int64, new RepresentationConverter(true, false)));
                 BsonSerializer.RegisterSerializer(typeof(UInt32), new UInt32Serializer(BsonType.Int64, new RepresentationConverter(true, false)));
                 BsonSerializer.RegisterSerializer(DateTimeSerializer.LocalInstance);
+                BsonSerializer.RegisterSerializer(typeof(float), new FloatTruncationSerializer());
             }
             catch (BsonSerializationException)
             {

--- a/src/TcoData/tests/TcoData.Repository.Integration.Tests/Repository/MongoDbSecuredRepositoryTest.cs
+++ b/src/TcoData/tests/TcoData.Repository.Integration.Tests/Repository/MongoDbSecuredRepositoryTest.cs
@@ -1,4 +1,4 @@
-﻿using TcOpen.Inxton.Data.MongoDb;
+﻿    using TcOpen.Inxton.Data.MongoDb;
 
 namespace TcoDataUnitTests
 {

--- a/src/TcoData/tests/TcoData.Repository.Integration.Tests/Repository/ZFloatSerializerMongoTests.cs
+++ b/src/TcoData/tests/TcoData.Repository.Integration.Tests/Repository/ZFloatSerializerMongoTests.cs
@@ -1,0 +1,90 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TcOpen.Inxton.Data;
+using TcOpen.Inxton.Data.MongoDb;
+
+namespace TcoDataUnitTests
+{
+    public class FloatSerializerObject : DataTestObject
+    {
+        public List<float> Floats { get; set; }
+    }
+
+    [TestFixture()]
+    // Due to some serialization error when running more tests at once, this has to run last.
+    public class ZFloatSerializerMongoTests
+    {
+        private List<float> Floats = new List<float>
+        {
+            float.MinValue,
+            float.MaxValue,
+            float.PositiveInfinity,
+            float.NegativeInfinity,
+            0.0f,
+            0.5f,
+            14.5f,
+            3.1415926535897932384626433832795028841971693993751058209749445923f,
+            (float.MaxValue /2),
+            (float.MaxValue /4),
+            (float.MaxValue /8),
+            (float.MaxValue /16),
+            (float.MaxValue /32),
+            float.Epsilon
+        };
+
+        protected IRepository<FloatSerializerObject> repository;
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            if (this.repository == null)
+            {
+                var a = new FloatSerializerObject();
+                var parameters = new MongoDbRepositorySettings<FloatSerializerObject>("mongodb://localhost:27017", "TestDataBase", nameof(ZFloatSerializerMongoTests));
+                this.repository = Repository.Factory<FloatSerializerObject>(parameters);
+                foreach (var item in this.repository.GetRecords("*"))
+                {
+                    repository.Delete(item._EntityId);
+                }
+            }
+        }
+
+        [Test, Order(1)]
+        public void CreateTest()
+        {
+            var toCreate = Enumerable.Range(0, 10)
+                .Select(x => new
+                {
+                    testObject = new FloatSerializerObject()
+                    {
+                        Name = "Pepo" + x, 
+                        DateOfBirth = DateTime.Now,
+                        Age = 15 + x,
+                        Floats = Floats 
+                    },
+                    id = $"test_{Guid.NewGuid()}"
+                }
+                ).ToList();
+
+            //-- Act
+            foreach (var x in toCreate)
+            {
+                repository.Create(x.id, x.testObject);
+            }
+
+            //-- Assert
+            Assert.True(repository.GetRecords().Count() == toCreate.Count);
+        }
+
+        [Test, Order(2)]
+        public void ReadTest()
+        {
+            var x = repository.GetRecords().ToList();
+            Assert.AreEqual(x.First().Floats, Floats);
+            //try to alter the values in robo3t and see if it reads again.
+        }
+
+    }
+}


### PR DESCRIPTION
Hi.

When you create a record with a float value in MongoDB, and then you edit it in Robo3T or Compass and try to read it back you get an error. 

This fix will take care of that in such a manner that when it serializes a float it will round it up to 10digits and store it as double. When you read the value back from the db, return it as float and also take into account some special cases.