### PR TITLE
Adding a role without refresh

### DIFF
--- a/src/TcOpen.Hammer/PlcHammer.Hmi.Blazor/Pages/Security.razor
+++ b/src/TcOpen.Hammer/PlcHammer.Hmi.Blazor/Pages/Security.razor
@@ -10,7 +10,7 @@
 
 
 
-<AuthorizeView Roles="administrator">
+<AuthorizeView>
     <Authorized>
         <UserManagementView></UserManagementView>
 
@@ -36,7 +36,8 @@
 
     public async Task CreateRole(string roleName)
     {
-
+        if (string.IsNullOrWhiteSpace(roleName))
+            return;
         if (!await _roleManager.RoleExistsAsync(roleName))
         {
             var normalizer = new UpperInvariantLookupNormalizer();

--- a/src/TcOpen.Hammer/PlcHammer.Hmi.Blazor/Pages/Security.razor
+++ b/src/TcOpen.Hammer/PlcHammer.Hmi.Blazor/Pages/Security.razor
@@ -12,7 +12,7 @@
 
 <AuthorizeView>
     <Authorized>
-        <UserManagementView></UserManagementView>
+        <UserManagementView @ref="@UserMgmtView"></UserManagementView>
 
         <div class="m-1">
             <h4>Add new role</h4>
@@ -34,6 +34,8 @@
 
     public string RoleName { get; set; }
 
+    private UserManagementView UserMgmtView { get;set;}
+
     public async Task CreateRole(string roleName)
     {
         if (string.IsNullOrWhiteSpace(roleName))
@@ -45,6 +47,7 @@
             identityRole.NormalizedName = normalizer.NormalizeName(roleName);
             await _roleManager.CreateAsync(identityRole);
             StateHasChanged();
+            UserMgmtView.RoleAdded();
         }
 
     }

--- a/src/TcOpen.Inxton/src/TcOpen.Inxton.Local.Security.Blazor/Views/UserManagementView.cs
+++ b/src/TcOpen.Inxton/src/TcOpen.Inxton.Local.Security.Blazor/Views/UserManagementView.cs
@@ -26,18 +26,23 @@ namespace TcOpen.Inxton.Local.Security.Blazor
         [Inject]
         private UserManager<User> _userManager { get; set; }
         [Inject]
-        private  SignInManager<User> _signInManager { get; set; }
+        private SignInManager<User> _signInManager { get; set; }
         [Inject]
-        private  RoleManager<IdentityRole> _roleManager { get; set; }
+        private RoleManager<IdentityRole> _roleManager { get; set; }
 
         private User SelectedUser { get; set; }
         private IList<RoleData> AvailableRoles { get; set; }
         private IList<RoleData> AssignedRoles { get; set; }
 
+        public void RoleAdded()
+        {
+            AvailableRoles = GetAvailableRoles();
+            StateHasChanged();
+        }
 
         public async Task AssignRoles()
         {
-            await _userManager.AddToRolesAsync(SelectedUser, AvailableRoles.Where(x => x.IsSelected == true).Select(x=>x.RoleName));
+            await _userManager.AddToRolesAsync(SelectedUser, AvailableRoles.Where(x => x.IsSelected == true).Select(x => x.RoleName));
             await RowClicked(SelectedUser);
         }
 
@@ -47,19 +52,19 @@ namespace TcOpen.Inxton.Local.Security.Blazor
             await RowClicked(SelectedUser);
         }
 
-      
+
         public async Task RowClicked(User user)
         {
             SelectedUser = user;
-            AssignedRoles =  (await _userManager.GetRolesAsync(user)).Select(x=> new RoleData(x)).ToList();
-            AvailableRoles = _roleManager.Roles
-                .Where(x => !AssignedRoles.Select(x=>x.RoleName).Contains(x.Name))
-                .Select(x=> new RoleData(x.Name))
-                .ToList();
-
-
+            AssignedRoles = (await _userManager.GetRolesAsync(user)).Select(x => new RoleData(x)).ToList();
+            AvailableRoles = GetAvailableRoles();
         }
 
+        private IList<RoleData> GetAvailableRoles() =>
+            _roleManager.Roles
+                .Where(x => !AssignedRoles.Select(x => x.RoleName).Contains(x.Name))
+                .Select(x => new RoleData(x.Name))
+                .ToList();
 
     }
 }


### PR DESCRIPTION
This PR fixes two issues

- App will not crash If you try to add an empty role
- When you add role you don't need to refresh the page.