### PR TITLE
Integration test succeeded when it shouldn't

### DIFF
--- a/src/IntegrationProjects/tests/IntegrationProjectTests/ExecuteWpfIntegrationProject.cs
+++ b/src/IntegrationProjects/tests/IntegrationProjectTests/ExecuteWpfIntegrationProject.cs
@@ -7,7 +7,7 @@ namespace IntegrationProjectTests
     public class ExecuteWpfIntegrationProject
     {       
         [Test]
-        [Timeout(10000)]
+        [Timeout(15000)]
         public void OpenApplicationTest()
         {
             var someAssemblyType = new Sandbox.IntegrationProjects.Wpf.App();
@@ -15,8 +15,8 @@ namespace IntegrationProjectTests
             var app = FlaUI.Core.Application.Launch(assembly.Location);
             using (var automation = new UIA3Automation())
             {
-                var window = app.GetMainWindow(automation);              
-                System.Threading.Thread.Sleep(2000);
+                var window = app.GetMainWindow(automation);
+                System.Threading.Thread.Sleep(5000);
                 window.Close();
             }
         }

--- a/src/IntegrationProjects/tests/Sandbox.IntegrationProjects.Wpf/MainWindowViewModel.cs
+++ b/src/IntegrationProjects/tests/Sandbox.IntegrationProjects.Wpf/MainWindowViewModel.cs
@@ -42,7 +42,7 @@ namespace Sandbox.IntegrationProjects.Wpf
                     .Build();
             Broker.StartAsync(mqttServerOptions);
 
-            var c = MqttFactory.CreateMqttClient();
+            var c = MqttFactory.CreateMqttClient().UseApplicationMessageReceivedHandler(new TcoAppMqttHandler());
             var mqttClientOptions = MqttFactory.CreateClientOptionsBuilder().WithTcpServer("broker.emqx.io").Build();
             c.ConnectAsync(mqttClientOptions, CancellationToken.None).Wait();
             return c;


### PR DESCRIPTION
Now the test waits for the app to start, so even ViewModel ist tested. 
Sometimes the app would not start completely and test would pass.