### PR TITLE
Fix menu title padding in template

### DIFF
--- a/src/TcOpenAppTemplates/StandardMtsTemplate/src/HmiTemplate.Wpf/App.xaml
+++ b/src/TcOpenAppTemplates/StandardMtsTemplate/src/HmiTemplate.Wpf/App.xaml
@@ -156,6 +156,9 @@
             -->
             <SolidColorBrush x:Key="MaterialDesignValidationErrorBrush" Color="{DynamicResource AlertColor}" />
             <SolidColorBrush x:Key="MaterialDesignDarkForeground" Color="{DynamicResource OnAlertColor}" />
+            <Style TargetType="{x:Type TextBlock}">
+                <Setter Property="Padding" Value="0,0,0,0"></Setter>
+            </Style>
         </ResourceDictionary>
 
     </Application.Resources>


### PR DESCRIPTION
I added a style that targets the weird padding in the template app.

another thing that's causing this issue is this line
```xml
<ResourceDictionary Source="pack://application:,,,/Vortex.Presentation.Styling.Wpf;component/MDOverrides.xaml" />
```

this is more of a quick fix rather than a fully-fledged fix. It looks like there's some issue with loading the textblock style. 

left tcopen app right mts template.
![image](https://user-images.githubusercontent.com/11136013/161021064-80cb3341-6aeb-4778-b2ce-90c69dd13852.png)
